### PR TITLE
Fixed input validation and query substitute

### DIFF
--- a/src/Plugin/facets/processor/YearRangeProcessor.php
+++ b/src/Plugin/facets/processor/YearRangeProcessor.php
@@ -85,7 +85,7 @@ class YearRangeProcessor extends ProcessorPluginBase implements PreQueryProcesso
       // Remove all the query filters for the field of the facet.
       if (isset($query[$filter_key])) {
         foreach ($query[$filter_key] as $id => $filter) {
-          if (strpos($filter . $url_processor->getSeparator(), $facet->getUrlAlias()) === 0) {
+          if (strpos($filter, $facet->getUrlAlias()) === 0) {
             unset($query[$filter_key][$id]);
           }
         }

--- a/src/Plugin/facets/widget/YearRangeWidget.php
+++ b/src/Plugin/facets/widget/YearRangeWidget.php
@@ -44,11 +44,11 @@ class YearRangeWidget extends WidgetPluginBase {
 
     $build['#items'] = [
       'min' => [
-        '#type' => 'number',
+        '#type' => 'textfield',
         '#title' => $this->t('From'),
         '#value' => $min,
         '#attributes' => [
-          'class' => ['facet-year-range'],
+          'class' => ['facet-yearpicker-min','facet-year-range'],
           'id' => $facet->id() . '_min',
           'name' => $facet->id() . '_min',
           'data-type' => 'year-range-min',
@@ -58,11 +58,11 @@ class YearRangeWidget extends WidgetPluginBase {
         '#theme_wrappers' => [],
       ],
       'max' => [
-        '#type' => 'number',
+        '#type' => 'textfield',
         '#title' => $this->t('To'),
         '#value' => $max,
         '#attributes' => [
-          'class' => ['facet-year-range'],
+          'class' => ['facet-yearpicker-max', 'facet-year-range'],
           'id' => $facet->id() . '_max',
           'name' => $facet->id() . '_max',
           'data-type' => 'year-range-max',
@@ -90,6 +90,7 @@ class YearRangeWidget extends WidgetPluginBase {
     $url = array_shift($results)->getUrl()->toString();
     $build['#attached']['library'][] = 'facets_year_range/year-range';
     $build['#attached']['drupalSettings']['facets']['daterange'][$facet->id()] = [
+      'alias' => $facet->getUrlAlias(),
       'url' => $url,
     ];
     return $build;


### PR DESCRIPTION
# Changes
- Input validation has been replaced in Javascript
  - Empty input will be prevented
  - Improper date ranges are prevented
  - Non-numerical inputs are prevented
- Added new class to the min, max input boxes for cleaner JS
- Changed min, max input type to 'textfield' to better prevent non-numerical inputs (Some reason setting input box to number type doesn't block non-numerical inputs)
- Widget will now return the url 'alias' for the facet in order for the JS to process
- Removed multiple hardcoded instances of 'publication_date' and instead uses the url 'alias'
  - This fixes the issue of query being appended instead of overridden